### PR TITLE
Return the result of invoked methods in benchmark

### DIFF
--- a/src/jmh/java/me/sunlan/fastreflection/FastMethodPerfTest.java
+++ b/src/jmh/java/me/sunlan/fastreflection/FastMethodPerfTest.java
@@ -79,6 +79,21 @@ public class FastMethodPerfTest {
         FAST_STRING_CONSTRUCTOR_CHAR_ARRAY.invoke(CHAR_ARRAY_OBJECT);
     }
 
+    @Benchmark
+    public boolean method_direct_StringStartsWith_Return() {
+        return "abc".startsWith("a");
+    }
+
+    @Benchmark
+    public Object method_reflect_StringStartsWith_Return() throws Throwable {
+        return STARTSWITH_METHOD.invoke("abc", "a");
+    }
+
+    @Benchmark
+    public Object method_fastreflect_StringStartsWith_Return() throws Throwable {
+        return FAST_STARTSWITH_METHOD.invoke("abc", "a");
+    }
+
     private static final Method STARTSWITH_METHOD;
     private static final FastMethod FAST_STARTSWITH_METHOD;
 


### PR DESCRIPTION
The JIT can do dead code elimination otherwise. Reference:
https://github.com/openjdk/jmh/blob/6f151470c8db1d8f2d3cd0e4d1ac24c314b461a4/jmh-samples/src/main/java/org/openjdk/jmh/samples/JMHSample_08_DeadCode.java#L65-L75

If the change makes sense to you, I'll add it for the constructor ones as well and remove the existing ones which do not blackhole the result. 

Results Report (excluding constructor benchmarks): https://gist.github.com/amCap1712/0ab5b7bb578610493d27cc42f2b1b75f#file-report-csv

There is a 10x difference between benchmarks that return and that don't for FastReflection and direct call. For reflection, the increase in time is comparitively less. Maybe the JIT was able to do dead code elimination in those two case but not in the case of normal reflection. Will need to do further investigation to explain it better though.
